### PR TITLE
add capability to filter matching links in browser history

### DIFF
--- a/src-test/test_settings_manager.js
+++ b/src-test/test_settings_manager.js
@@ -24,6 +24,7 @@ TestSettingsManager.prototype.testInitWindows = function() {
 					"delay": 0,
 					"close": 0,
 					"block": true,
+					"history": false,
 					"reverse": false,
 					"end": false
 				}
@@ -59,6 +60,7 @@ TestSettingsManager.prototype.testInitLinux = function() {
 					"delay": 0,
 					"close": 0,
 					"block": true,
+					"history": false,
 					"reverse": false,
 					"end": false
 				}
@@ -83,13 +85,17 @@ TestSettingsManager.prototype.testSave = function() {
 	assertEquals(0, settings.actions[101].options.smart)
 	
 	settings.actions[101].options.smart = 1;
+	settings.actions[101].options.history = true;
 	
 	sm.save(settings);
 	
 	var new_settings = sm.load();
 	
 	assertEquals(1, new_settings.actions[101].options.smart)
+	assertEquals(true, new_settings.actions[101].options.history)
 }
+
+
 
 TestSettingsManager.prototype.testError = function() {
 	var sm = new SettingsManager(OS_WIN);
@@ -107,6 +113,7 @@ TestSettingsManager.prototype.testError = function() {
 						"delay": 0,
 						"close": 0,
 						"block": true,
+						"history": false,
 						"reverse": false,
 						"end": false
 					}

--- a/src/background.js
+++ b/src/background.js
@@ -170,11 +170,14 @@ function handleRequests(request, sender, callback){
 			request.urls = request.urls.unique();
 		}
 
+		console.log(Date.now())
+
 		if(request.setting.options.history){
 
-			// setting startTime to 0 and maxResults to Number.MAX_SAFE_INTEGER so to get every links in chrome history
-			chrome.history.search({text:"", startTime:0, maxResults:2^32-1}, function(items){
+			// setting startTime to 0 and maxResults to largest 32bit signed interger so to get every links in chrome history
+			chrome.history.search({text:"", startTime:0, maxResults:2147483647}, function(items){
 
+				console.log(items.length)
 				allHistories = items.map(function(e){
 					return e.url;
 				});
@@ -183,6 +186,7 @@ function handleRequests(request, sender, callback){
 
 					return allHistories.indexOf(e.url) === -1;
 				});
+				console.log(Date.now())
 
 				handleActivate(request, sender)
 

--- a/src/background.js
+++ b/src/background.js
@@ -74,6 +74,95 @@ function timeConverter(a){
 	return time;
 }
 
+function handleActivate(request, sender){
+	if(request.urls.length === 0) {
+			return;
+		}
+
+	if(request.setting.options.reverse) {
+		request.urls.reverse();
+	}
+
+	switch(request.setting.action) {
+	case 'copy':
+		var text = "";
+		for (i = 0; i < request.urls.length; i++) {
+			switch(request.setting.options.copy) {
+			case "0":
+				text += request.urls[i].title+"\t"+request.urls[i].url+"\n";
+				break;
+			case "1":
+				text += request.urls[i].url+"\n";
+				break;
+			case "2":
+				text += request.urls[i].title+"\n";
+				break;
+			case "3":
+				text += '<a href="'+request.urls[i].url+'">'+request.urls[i].title+'</a>\n';
+				break;
+			case "4":
+				text += '<li><a href="'+request.urls[i].url+'">'+request.urls[i].title+'</a></li>\n';
+				break;
+			case "5":
+				text += "["+request.urls[i].title+"]("+request.urls[i].url+")\n";
+				break;
+			}
+		}
+
+		if(request.setting.options.copy == 4) {
+			text = '<ul>\n'+text+'</ul>\n'
+		}
+
+		copyToClipboard(text);
+		break;
+	case 'bm':
+		chrome.bookmarks.getTree(
+			function(bookmarkTreeNodes) {
+				// make assumption that bookmarkTreeNodes[0].children[1] refers to the "other bookmarks" folder
+				// as different languages will not use the english name to refer to the folder
+				chrome.bookmarks.create({'parentId': bookmarkTreeNodes[0].children[1].id, 'title': 'Linkclump '+timeConverter(new Date())},
+					function(newFolder) {
+						for (j = 0; j < request.urls.length; j++) {
+							chrome.bookmarks.create({'parentId': newFolder.id,
+								'title': request.urls[j].title,
+								'url': request.urls[j].url});
+						}
+					}
+				);
+			}
+		);
+
+		break;
+	case 'win':
+		chrome.windows.getCurrent(function(current_window){
+
+			chrome.windows.create({url: request.urls.shift().url, "focused" : !request.setting.options.unfocus}, function(window){
+				if(request.urls.length > 0) {
+					openTab(request.urls, request.setting.options.delay, window.id, null, 0);
+				}
+			});
+
+			if(request.setting.options.unfocus) {
+				chrome.windows.update(current_window.id, {"focused": true});
+			}
+		});
+		break;
+	case 'tabs':
+		chrome.tabs.get(sender.tab.id, function(tab) {
+			chrome.windows.getCurrent(function(window){
+				var tab_index = null;
+
+				if(!request.setting.options.end) {
+					tab_index = tab.index+1;
+				}
+
+				openTab(request.urls, request.setting.options.delay, window.id, tab_index, request.setting.options.close);
+			})
+		});
+		break;
+	}
+}
+
 function handleRequests(request, sender, callback){
 	switch(request.message) {
 	case 'activate':
@@ -81,91 +170,25 @@ function handleRequests(request, sender, callback){
 			request.urls = request.urls.unique();
 		}
 
-		if(request.urls.length === 0) {
-			return;
-		}
+		if(request.setting.options.history){
 
-		if(request.setting.options.reverse) {
-			request.urls.reverse();
-		}
+			// setting startTime to 0 and maxResults to Number.MAX_SAFE_INTEGER so to get every links in chrome history
+			chrome.history.search({text:"", startTime:0, maxResults:2^32-1}, function(items){
 
-		switch(request.setting.action) {
-		case 'copy':
-			var text = "";
-			for (i = 0; i < request.urls.length; i++) {
-				switch(request.setting.options.copy) {
-				case "0":
-					text += request.urls[i].title+"\t"+request.urls[i].url+"\n";
-					break;
-				case "1": 
-					text += request.urls[i].url+"\n";
-					break;
-				case "2":
-					text += request.urls[i].title+"\n";
-					break;
-				case "3":
-					text += '<a href="'+request.urls[i].url+'">'+request.urls[i].title+'</a>\n';
-					break;
-				case "4":
-					text += '<li><a href="'+request.urls[i].url+'">'+request.urls[i].title+'</a></li>\n';
-					break;
-				case "5":
-					text += "["+request.urls[i].title+"]("+request.urls[i].url+")\n";
-					break;
-				}
-			}
-			
-			if(request.setting.options.copy == 4) {
-				text = '<ul>\n'+text+'</ul>\n'
-			}
-			
-			copyToClipboard(text);
-			break;
-		case 'bm':
-			chrome.bookmarks.getTree(
-				function(bookmarkTreeNodes) {
-					// make assumption that bookmarkTreeNodes[0].children[1] refers to the "other bookmarks" folder
-					// as different languages will not use the english name to refer to the folder
-					chrome.bookmarks.create({'parentId': bookmarkTreeNodes[0].children[1].id, 'title': 'Linkclump '+timeConverter(new Date())},
-						function(newFolder) {
-							for (j = 0; j < request.urls.length; j++) {
-								chrome.bookmarks.create({'parentId': newFolder.id,
-									'title': request.urls[j].title,
-									'url': request.urls[j].url});
-							}
-						}
-					);
-				}
-			);
-
-			break;
-		case 'win':
-			chrome.windows.getCurrent(function(current_window){
-
-				chrome.windows.create({url: request.urls.shift().url, "focused" : !request.setting.options.unfocus}, function(window){
-					if(request.urls.length > 0) {
-						openTab(request.urls, request.setting.options.delay, window.id, null, 0);
-					}
+				allHistories = items.map(function(e){
+					return e.url;
 				});
 
-				if(request.setting.options.unfocus) {
-					chrome.windows.update(current_window.id, {"focused": true});
-				}
-			});
-			break;
-		case 'tabs':
-			chrome.tabs.get(sender.tab.id, function(tab) {
-				chrome.windows.getCurrent(function(window){
-					var tab_index = null;
+				request.urls = request.urls.filter(function(e){
 
-					if(!request.setting.options.end) {
-						tab_index = tab.index+1;
-					}
+					return allHistories.indexOf(e.url) === -1;
+				});
 
-					openTab(request.urls, request.setting.options.delay, window.id, tab_index, request.setting.options.close);
-				})
-			});
-			break;
+				handleActivate(request, sender)
+
+			})
+		}else{
+			handleActivate(request, sender)
 		}
 
 		break;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,7 @@
     }
   ],
   "permissions": [
-    "tabs", "bookmarks", "http://*/*", "https://*/*"
+    "tabs", "bookmarks", "history", "http://*/*", "https://*/*"
   ],
   "web_accessible_resources": [
     "pages/test_area.html"

--- a/src/pages/options.js
+++ b/src/pages/options.js
@@ -2,10 +2,10 @@ var config = {
 	"triggers": 
 		[{"name": "Left"}, {"name": "Middle"}, {"name": "Right"}],
 	"actions": {
-		"win": {"name": "Opened in a New Window", "options": ["smart", "ignore", "delay", "block", "reverse", "unfocus"]},
-		"tabs": {"name": "Opened as New Tabs", "options": ["smart", "ignore", "delay", "close", "block", "reverse", "end"]},
-		"bm": {"name": "Bookmarked", "options": ["smart", "ignore", "block", "reverse"]},
-		"copy": {"name": "Copied to clipboard", "options": ["smart", "ignore", "copy", "block", "reverse"]}
+		"win": {"name": "Opened in a New Window", "options": ["smart", "ignore", "delay", "block", "history", "reverse", "unfocus"]},
+		"tabs": {"name": "Opened as New Tabs", "options": ["smart", "ignore", "delay", "close", "block", "history", "reverse", "end"]},
+		"bm": {"name": "Bookmarked", "options": ["smart", "ignore", "block", "history", "reverse"]},
+		"copy": {"name": "Copied to clipboard", "options": ["smart", "ignore", "copy", "block", "history", "reverse"]}
 	},
 	"options": {
 		"smart": {
@@ -40,6 +40,11 @@ var config = {
 		"name": "block repeat links in selection",
 		"type": "checkbox",
 		"extra":"select to block repeat links from opening"
+		},
+	"history": {
+		"name": "filter visited links",
+		"type": "checkbox",
+		"extra":"filter matching links against browser history"
 		},
 	"reverse": {
 		"name": "reverse order",

--- a/src/pages/options.js
+++ b/src/pages/options.js
@@ -42,7 +42,7 @@ var config = {
 		"extra":"select to block repeat links from opening"
 		},
 	"history": {
-		"name": "filter visited links",
+		"name": "filter visited links(uncheck to improve performance)",
 		"type": "checkbox",
 		"extra":"filter matching links against browser history"
 		},

--- a/src/settings_manager.js
+++ b/src/settings_manager.js
@@ -52,6 +52,7 @@ SettingsManager.prototype.init = function() {
 						"delay": 0,
 						"close": 0,
 						"block": true,
+						"history": false,
 						"reverse": false,
 						"end": false
 					}


### PR DESCRIPTION
I received a freelancer task a few days ago that when extracting links using this plugin, also filter what's already in browser history. That's already been done, so thinking whether could this be a possible pull request to the main repository. 

Here's the brief changes I've done:
* add "history" to manifest to allow reading browser history
* add a new option "filter visited links", default to unchecked. 
* When the option is checked, read ALL chrome browser histories to filter against
* All test passed

The code changing is fairly straight forward, if you need further information, or further updating, please give feedback :)

Thanks!