### PR TITLE
Reject empty or # hrefs

### DIFF
--- a/src/linkclump.js
+++ b/src/linkclump.js
@@ -286,6 +286,11 @@ function start() {
 		if (re1.test(page_links[i].href)) {
 			continue;
 		}
+		
+		// reject href="" or href="#"
+		if (!page_links[i].getAttribute("href") || page_links[i].getAttribute("href")) === "#") {
+			continue;
+		}
 
 		// include/exclude links
 		if (this.settings[this.setting].options.ignore.length > 1) {


### PR DESCRIPTION
These are commonly used for links that invoke JavaScript on click, and should be omitted similar to `javascript:` links.