### PR TITLE
"tabs" permission not needed

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,7 @@
     }
   ],
   "permissions": [
-    "tabs", "bookmarks", "http://*/*", "https://*/*"
+    "bookmarks", "http://*/*", "https://*/*"
   ],
   "web_accessible_resources": [
     "pages/test_area.html"


### PR DESCRIPTION
The current implementation doesn't seem to use the "tabs" permission.

Per the documentation at https://developer.chrome.com/extensions/tabs none of the restricted APIs seem to be used.