### PR TITLE
fix: not concerning transform matrix during calculation of offset

### DIFF
--- a/examples/offset-with-transform.html
+++ b/examples/offset-with-transform.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .item {
+      position: absolute;
+      left: 10px;
+      height: 30px;
+      width: 80px;
+    }
+  </style>
+</head>
+<body>
+
+<h1>By only transform</h1>
+
+<div style="position: relative; height: 200px;">
+  <div class="item" style="transform: translate(10px, 10px);">
+    <a href="#item-01">item-01</a>
+  </div>
+
+  <div class="item" style="transform: translate(50px, 50px);">
+    <a href="#item-02">item-02</a>
+  </div>
+
+  <div class="item" style="transform: translate(90px, 90px);">
+    <a href="#item-03">item-03</a>
+  </div>
+</div>
+
+<h1>By offset and transform</h1>
+
+<div style="position: relative;">
+  <div class="item" style="left: 10px; top: 10px; transform: translate(10px, 10px);">
+    <a href="#item-01">item-01</a>
+  </div>
+
+  <div class="item" style="left: 50px; top: 50px; transform: translate(50px, 50px);">
+    <a href="#item-02">item-02</a>
+  </div>
+
+  <div class="item" style="left: 90px; top: 90px; transform: translate(90px, 90px);">
+    <a href="#item-03">item-03</a>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/linkclump.js
+++ b/src/linkclump.js
@@ -242,10 +242,15 @@ function mouseup(event) {
 function getXY(element) {
 	var x = 0;
 	var y = 0;
+
 	var parent = element;
+	var style;
+	var matrix;
 	do {
-		x += parent.offsetLeft;
-		y += parent.offsetTop;
+		style = window.getComputedStyle(parent);
+		matrix = new WebKitCSSMatrix(style.webkitTransform);
+		x += parent.offsetLeft + matrix.m41;
+		y += parent.offsetTop + matrix.m42;
 	} while (parent = parent.offsetParent);
 
 	parent = element;


### PR DESCRIPTION
I posted a demo file <examples/offset-with-transform.html>, which results in bad case.
![image](https://user-images.githubusercontent.com/55376326/68066690-0185eb00-fd77-11e9-9320-98ced0f6f102.png)

Transform style is somehow a little popularly used when laying out a table.
[Explanation for `.m41` and `.m42`](https://stackoverflow.com/questions/5968227/get-the-value-of-webkit-transform-of-an-element-with-jquery/5968313#5968313)

Still, I do not concern transform with rotation/skew, because that will be too complicated.
