### PR TITLE
fix: cheome.tabs.create API change

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,7 @@ function openTab(urls, delay, windowId, tabPosition, closeTime) {
 	var obj = {
 			windowId: windowId,
 			url: urls.shift().url,
-			selected: false
+			active: false
 	};
 
 	if(tabPosition != null) {


### PR DESCRIPTION
`selected` is [deprecated](https://developer.chrome.com/docs/extensions/reference/tabs/#method-create)

