### PR TITLE
Assign openerTabId for created tabs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -13,9 +13,10 @@ Array.prototype.unique = function() {
 	return a;
 };
 
-function openTab(urls, delay, windowId, tabPosition, closeTime) {
+function openTab(urls, delay, windowId, openerTabId, tabPosition, closeTime) {
 	var obj = {
-			windowId: windowId,
+			windowId,
+			openerTabId,
 			url: urls.shift().url,
 			active: false
 	};
@@ -34,7 +35,7 @@ function openTab(urls, delay, windowId, tabPosition, closeTime) {
 	});
 
 	if(urls.length > 0) {
-		window.setTimeout(function() {openTab(urls, delay, windowId, tabPosition, closeTime)}, delay*1000);
+		window.setTimeout(function() {openTab(urls, delay, windowId, openerTabId, tabPosition, closeTime)}, delay*1000);
 	}
 
 }
@@ -141,7 +142,7 @@ function handleRequests(request, sender, callback){
 
 				chrome.windows.create({url: request.urls.shift().url, "focused" : !request.setting.options.unfocus}, function(window){
 					if(request.urls.length > 0) {
-						openTab(request.urls, request.setting.options.delay, window.id, null, 0);
+						openTab(request.urls, request.setting.options.delay, window.id, undefined, null, 0);
 					}
 				});
 
@@ -159,7 +160,7 @@ function handleRequests(request, sender, callback){
 						tab_index = tab.index+1;
 					}
 
-					openTab(request.urls, request.setting.options.delay, window.id, tab_index, request.setting.options.close);
+					openTab(request.urls, request.setting.options.delay, window.id, tab.id, tab_index, request.setting.options.close);
 				})
 			});
 			break;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Linkclump",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Lets you open, copy or bookmark multiple links at the same time.",
   "background": {
     "scripts": ["settings_manager.js", "background.js"],


### PR DESCRIPTION
- Pass opener tab's ID to openTab() if in the same window, mirroring the browser's native tab behaviour and allowing it and/or other extensions to identify the origin of created tabs
- Bump version (patch) to 2.9.3