### PR TITLE
Migrate to manifest v3

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -221,11 +221,12 @@ function handleRequests(request, sender, callback){
 	}
 }
 
+// needed only to detect reloading/update of extension
+chrome.runtime.onConnect.addListener(() => {});
+
 chrome.runtime.onMessage.addListener(handleRequests)
 
 settingsManager.initOrUpdate().then(firstRun => {
-	if (!firstRun) return
-
 	// inject Linkclump into windows currently open to make it just work
 	chrome.windows.getAll({ populate: true }, function(windows) {
 		for (var i = 0; i < windows.length; ++i) {
@@ -240,8 +241,10 @@ settingsManager.initOrUpdate().then(firstRun => {
 		}
 	});
 
-	// show tour and options page
-	chrome.tabs.create({
-		url: chrome.runtime.getURL('pages/options.html') + "?init=true",
-	});
+	if (firstRun) {
+		// show tour and options page
+		chrome.tabs.create({
+			url: chrome.runtime.getURL('pages/options.html') + "?init=true",
+		});
+	}
 });

--- a/src/copy_to_clipboard.html
+++ b/src/copy_to_clipboard.html
@@ -1,0 +1,1 @@
+<script src="copy_to_clipboard.js"></script>

--- a/src/copy_to_clipboard.js
+++ b/src/copy_to_clipboard.js
@@ -1,0 +1,10 @@
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.message !== 'copy-to-clipboard') return
+
+  const textarea = document.createElement('textarea');
+  document.body.appendChild(textarea);
+  textarea.value = request.text;
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+});

--- a/src/linkclump.js
+++ b/src/linkclump.js
@@ -25,16 +25,12 @@ var scroll_bug_ignore = false;
 var os = ((navigator.appVersion.indexOf("Win") === -1) ? OS_LINUX : OS_WIN);
 var timer = 0;
 
-chrome.extension.sendMessage({
+chrome.runtime.sendMessage({
 	message: "init"
-}, function(response) {
+}).then(response => {
 	if (response === null) {
 		console.log("Unable to load linkclump due to null response");
 	} else {
-		if (response.hasOwnProperty("error")) {
-			console.log("Unable to properly load linkclump, returning to default settings: " + JSON.stringify(response));
-		}
-
 		settings = response.actions;
 
 		var allowed = true;
@@ -58,7 +54,7 @@ chrome.extension.sendMessage({
 	}
 });
 
-chrome.extension.onMessage.addListener(function(request, sender, callback) {
+chrome.runtime.onMessage.addListener(function(request, sender, callback) {
 	if (request.message === "update") {
 		this.settings = request.settings.actions;
 	}
@@ -494,7 +490,7 @@ function detech(x, y, open) {
 	count_label.innerText = count_tabs.size;
 
 	if (open_tabs.length > 0) {
-		chrome.extension.sendMessage({
+		chrome.runtime.sendMessage({
 			message: "activate",
 			urls: open_tabs,
 			setting: this.settings[this.setting]

--- a/src/linkclump.js
+++ b/src/linkclump.js
@@ -45,6 +45,14 @@ chrome.runtime.sendMessage({
 		}
 
 		if (allowed) {
+			chrome.runtime.connect().onDisconnect.addListener(() => {
+				window.removeEventListener("mousedown", this.mousedown, true);
+				window.removeEventListener("keydown", this.keydown, true);
+				window.removeEventListener("keyup", this.keyup, true);
+				window.removeEventListener("blur", this.blur, true);
+				window.removeEventListener("contextmenu", this.contextmenu, true);
+			});
+
 			window.addEventListener("mousedown", this.mousedown, true);
 			window.addEventListener("keydown", this.keydown, true);
 			window.addEventListener("keyup", this.keyup, true);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Linkclump",
   "version": "2.9.5",
   "description": "Lets you open, copy or bookmark multiple links at the same time.",
   "background": {
-    "scripts": ["settings_manager.js", "background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
   "options_page": "pages/options.html",
   "icons": {"16": "images/16x16.png",
@@ -20,9 +19,17 @@
     }
   ],
   "permissions": [
-    "bookmarks", "http://*/*", "https://*/*"
+    "bookmarks",
+    "scripting",
+    "storage"
   ],
-  "web_accessible_resources": [
-    "pages/test_area.html"
-  ]
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+  "web_accessible_resources": [{
+    "resources": ["pages/test_area.html"],
+    "matches": [],
+    "extension_ids": []
+  }]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,6 +20,8 @@
   ],
   "permissions": [
     "bookmarks",
+    "clipboardWrite",
+    "offscreen",
     "scripting",
     "storage"
   ],

--- a/src/pages/options.js
+++ b/src/pages/options.js
@@ -502,7 +502,7 @@ function save_action(event) {
 }
 
 function save_params() {
-	chrome.extension.sendMessage({
+	chrome.runtime.sendMessage({
 		message: "update",
 		settings: params
 	});
@@ -537,7 +537,7 @@ $(function() {
 
 	setup_form();
 
-	chrome.extension.sendMessage({
+	chrome.runtime.sendMessage({
 		message: "init"
 	}, function(response){
 		params = response;

--- a/src/pages/test.css
+++ b/src/pages/test.css
@@ -5,7 +5,7 @@ body {
 	padding: 0px;
 }
 
-p {
+h1, p {
 	text-align: center;
 }
 
@@ -30,5 +30,5 @@ ul {
 }
 
 li {
-	padding: 15px;
+	padding: 10px;
 }

--- a/src/pages/test_area.html
+++ b/src/pages/test_area.html
@@ -6,11 +6,12 @@
 	</head>
 	<body>
 		<p>Try linkclump in this yellow test area.</p>
+		<h1><a href="https://example.com">Important link (smart test)</a></p>
 		<ul>
-			<li><a href="http://www.google.com/">Google</a></li>
-			<li><a href="http://www.bing.com/">Bing</a></li>
-			<li><a href="http://www.yahoo.com/">Yahoo</a></li>
-			<li><a href="http://duckduckgo.com/">DuckDuckGo<a></li>
+			<li><a href="https://www.google.com/">Google</a></li>
+			<li><a href="https://www.bing.com/">Bing</a></li>
+			<li><a href="https://www.yahoo.com/">Yahoo</a></li>
+			<li><a href="https://duckduckgo.com/">DuckDuckGo<a></li>
 		</ul>
 	</body>
 </html>


### PR DESCRIPTION
Trying a minimalistic migration to manifest v3:
* use `storage.local` for settings, so `SettingsManager` returns promises now
* use offscreen document for copying to clipboard
* handle reloading/updating of extension